### PR TITLE
Changes for Gluon v2016.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     git checkout v201x.x                                           # Switch to Gluon release if not master (see below)
     git clone git://github.com/freifunkerfurt/site-ffef.git site   # Get the Freifunk Erfurt site repository
     make update                                                    # Get other repositories used by Gluon
-    make                                                           # Build Gluon
+    make GLUON_TARGET=ar71xx-generic                               # Build Gluon
 
 Please see [the official Gluon repository](https://github.com/freifunk-gluon/gluon) for an in-depth explanation of the build process.
 

--- a/site.mk
+++ b/site.mk
@@ -1,7 +1,6 @@
 GLUON_SITE_PACKAGES := \
 	gluon-mesh-batman-adv-14 \
 	gluon-alfred \
-	gluon-announced \
 	gluon-autoupdater \
 	gluon-config-mode-hostname \
 	gluon-config-mode-autoupdater \
@@ -18,6 +17,7 @@ GLUON_SITE_PACKAGES := \
 	gluon-next-node \
 	gluon-mesh-vpn-fastd \
 	gluon-radvd \
+	gluon-respondd \
 	gluon-setup-mode \
 	gluon-status-page \
 	iwinfo \


### PR DESCRIPTION
Built the Freifunk Erfurt Firmware with Gluon v2016.1.5 for a TP-Link TL-WR841N v11.1, today.

Noticed the following changes might be useful for the site config.

```
The packages gluon-announce and gluon-announced were merged into the package gluon-respondd. If you had any of them (probably gluon-announced) in your package list, you have to replace them.
```
Source: https://gluon.readthedocs.io/en/v2016.1/releases/v2016.1.html

```
Gluon v2015.1 is the first release to officially support hardware that is not handled by the ar71xx-generic OpenWrt target. This also means that ar71xx-generic isn’t the default target anymore, the GLUON_TARGET variable must be set for all runs of make and make clean now.
```
Source: http://gluon.readthedocs.io/en/v2016.1/releases/v2015.1.html