### PR TITLE
Update site.conf

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -8,9 +8,9 @@
 
 	timezone = 'CET-1CEST,M3.5.0,M10.5.0/3', -- Europe/Berlin
 	ntp_servers = {
-		'pool.ntp.org',
 		'ntp1.ffef',
-		'ntp2.ffef'
+		'ntp2.ffef',
+		'2.de.pool.ntp.org',
 	},
 	regdom = 'DE',
 

--- a/site.conf
+++ b/site.conf
@@ -10,7 +10,6 @@
 	ntp_servers = {
 		'ntp1.ffef',
 		'ntp2.ffef',
-		'2.de.pool.ntp.org',
 	},
 	regdom = 'DE',
 


### PR DESCRIPTION
interne Server priorisieren
2.de.pool.ntp.org ist der pool für Deutschland
alle anderen de-Pools haben keine IPv6 Adressen gesetzt