### PR TITLE
remove obsolete autoupdater probability setting and set PRIORITY

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -89,7 +89,6 @@
 					'http://firmware.ffef/stable/sysupgrade',
 					'http://firmware.erfurt.freifunk.net/stable/sysupgrade',
 				},
-				probability = 0.08,
 				good_signatures = 2,
 				pubkeys = {
 					'bd7ba472ad1b230c4585d6da44655d113086b95d71094a40f275d3cb894347fb', -- mape2k
@@ -104,7 +103,6 @@
 					'http://firmware.ffef/beta/sysupgrade',
 					'http://firmware.erfurt.freifunk.net/beta/sysupgrade',
 				},
-				probability = 0.08,
 				good_signatures = 2,
 				pubkeys = {
 					'bd7ba472ad1b230c4585d6da44655d113086b95d71094a40f275d3cb894347fb', -- mape2k
@@ -119,7 +117,6 @@
 					'http://firmware.ffef/experimental/sysupgrade',
 					'http://firmware.erfurt.freifunk.net/experimental/sysupgrade',
 				},
-				probability = 1.00,
 				good_signatures = 2,
 				pubkeys = {
 					'bd7ba472ad1b230c4585d6da44655d113086b95d71094a40f275d3cb894347fb', -- mape2k

--- a/site.mk
+++ b/site.mk
@@ -30,7 +30,7 @@ DEFAULT_GLUON_RELEASE := 1.3.2
 # Allow overriding the release number from the command line
 GLUON_RELEASE ?= $(DEFAULT_GLUON_RELEASE)
 
-GLUON_PRIORITY ?= 0
+GLUON_PRIORITY ?= 14
 
 GLUON_LANGS ?= de en
 


### PR DESCRIPTION
The probability setting was removed in 2014 https://github.com/freifunk-gluon/gluon/commit/bb2adefd3456d766c9a7ea1d99440404239a55c8

The PRIORITY setting in the manifest file does something similar

> A manifest file for the updater can be generated with `make manifest`. A signing script (using
> ``ecdsautils``) can by found in the `contrib` directory. When creating the manifest, the 
> ``PRIORITY`` value may be defined by setting ``GLUON_PRIORITY`` on the command line or in ``site.mk``.
> 
> ``GLUON_PRIORITY`` defines the maximum number of days that may pass between releasing an update and installation
> of the images. The update probability will start at 0 after the release time declared in the manifest file
> by the variable DATE and then slowly rise up to 1 when ``GLUON_PRIORITY`` days have passed. The autoupdater checks
> for updates hourly (at a random minute of the hour), but usually only updates during its run between
> 4am and 5am, except when the whole ``GLUON_PRIORITY`` days and another 24 hours have passed.

https://github.com/freifunk-gluon/gluon/blob/master/docs/features/autoupdater.rst