### PR TITLE
The GLUON_ATH10K_MESH variable was renamed to GLUON_WLAN_MESH

### DIFF
--- a/site.mk
+++ b/site.mk
@@ -37,4 +37,4 @@ GLUON_LANGS ?= de en
 GLUON_REGION := eu
 
 # Build images with ath10k-based drivers for IBSS (Ad-Hoc)
-GLUON_ATH10K_MESH := ibss
+GLUON_WLAN_MESH := ibss


### PR DESCRIPTION
Should be `GLUON_WLAN_MESH := ibss` or `GLUON_WLAN_MESH := 11s`

https://gluon.readthedocs.io/en/v2018.2.x/user/site.html#build-configuration
```
GLUON_WLAN_MESH
Setting this to 11s or ibss will enable generation of matching images for devices
which don’t support both meshing modes, either at all (e.g. ralink and mediatek
don’t support AP+IBSS) or in the same firmware (ath10k-based 5GHz).
Defaults to 11s.
```