### PR TITLE
run-build.sh: workaround broken Github repository addresses

### DIFF
--- a/contrib/actions/run-build.sh
+++ b/contrib/actions/run-build.sh
@@ -11,6 +11,7 @@ export BUILD_LOG=1
 
 echo "Workaround broken git:// Github repos"
 git config --global url."https://github.com/".insteadOf git://github.com/
+git config --global --list
 
 echo "Baue Target: "$GLUON_TARGET
 echo "make -C gluon update"

--- a/contrib/actions/run-build.sh
+++ b/contrib/actions/run-build.sh
@@ -9,6 +9,9 @@ export GLUON_SITEDIR="./site/"
 export GLUON_TARGET=$1
 export BUILD_LOG=1
 
+echo "Workaround broken git:// Github repos"
+git config --global url."https://github.com/".insteadOf git://github.com/
+
 echo "Baue Target: "$GLUON_TARGET
 echo "make -C gluon update"
 make -C gluon update >> logs/$GLUON_TARGET.log


### PR DESCRIPTION
Is the workaround needed in the nightly branch? Does the workflow run the contrib scripts of the selected branch, only?

Add output of `git config --list` to verify usage.