### PR TITLE
Update to Gluon v2022.1.4

### DIFF
--- a/contrib/actions/install-dependencies.sh
+++ b/contrib/actions/install-dependencies.sh
@@ -5,7 +5,7 @@ set -e
 cp /home/runner/work/site-ffef/site-ffef/contrib/actions/sources.list /etc/apt/sources.list
 rm -rf /etc/apt/sources.list.d
 apt update
-apt install subversion build-essential libncurses-dev python2.7 python3 zlib1g-dev
+apt install subversion build-essential libncurses-dev python2.7 python3 qemu-utils zlib1g-dev
 apt clean
 rm -rf /var/lib/apt/lists/*
 dpkg -l

--- a/domains/ffef_v1.conf
+++ b/domains/ffef_v1.conf
@@ -43,11 +43,9 @@
   },
 
   mesh_vpn = {
-
-    mtu = 1426,
-
     fastd = {
       methods = {'null+salsa2012+umac'},
+      mtu = 1426,
       groups = {
         backbone = {
           limit = 1,

--- a/domains/ffen_v1.conf
+++ b/domains/ffen_v1.conf
@@ -43,11 +43,9 @@
   },
 
   mesh_vpn = {
-
-    mtu = 1426,
-
     fastd = {
       methods = {'null+salsa2012+umac'},
+      mtu = 1426,
       groups = {
         backbone = {
           limit = 1,

--- a/domains/ffgth_v1.conf
+++ b/domains/ffgth_v1.conf
@@ -43,11 +43,9 @@
   },
 
   mesh_vpn = {
-
-    mtu = 1426,
-
     fastd = {
       methods = {'null+salsa2012+umac'},
+      mtu = 1426,
       groups = {
         backbone = {
           limit = 1,

--- a/domains/ffil_v1.conf
+++ b/domains/ffil_v1.conf
@@ -43,11 +43,9 @@
   },
 
   mesh_vpn = {
-
-    mtu = 1426,
-
     fastd = {
       methods = {'null+salsa2012+umac'},
+      mtu = 1426,
       groups = {
         backbone = {
           limit = 1,

--- a/domains/ffthw_v1.conf
+++ b/domains/ffthw_v1.conf
@@ -43,11 +43,9 @@
   },
 
   mesh_vpn = {
-
-    mtu = 1426,
-
     fastd = {
       methods = {'null+salsa2012+umac'},
+      mtu = 1426,
       groups = {
         backbone = {
           limit = 1,

--- a/domains/ffwsee_v1.conf
+++ b/domains/ffwsee_v1.conf
@@ -43,11 +43,9 @@
   },
 
   mesh_vpn = {
-
-    mtu = 1426,
-
     fastd = {
       methods = {'null+salsa2012+umac'},
+      mtu = 1426,
       groups = {
         backbone = {
           limit = 1,

--- a/site.mk
+++ b/site.mk
@@ -42,7 +42,7 @@ GLUON_SITE_PACKAGES := \
 #			opkg compare-versions "$1" '>>' "$2"
 #		to decide if a version is newer or not.
 
-DEFAULT_GLUON_RELEASE := 2021.1.2.1
+DEFAULT_GLUON_RELEASE := 2022.1.4
 
 # Variables set with ?= can be overwritten from the command line
 


### PR DESCRIPTION
**Gluon v2022.1.4**

* https://gluon.readthedocs.io/en/latest/releases/v2022.1.html
  * https://gluon.readthedocs.io/en/latest/releases/v2022.1.1.html
  * https://gluon.readthedocs.io/en/latest/releases/v2022.1.2.html
  * https://gluon.readthedocs.io/en/latest/releases/v2022.1.3.html
  * https://gluon.readthedocs.io/en/latest/releases/v2022.1.4.html